### PR TITLE
Fix: custom buttons on science and operations

### DIFF
--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -82,7 +82,7 @@ ScienceScreen::ScienceScreen(GuiContainer* owner, ECrewPosition crew_position)
     info_sidebar->setPosition(-20, 170, ATopRight)->setSize(250, GuiElement::GuiSizeMax);
 
     custom_function_sidebar = new GuiCustomShipFunctions(radar_view, crew_position, "");
-    custom_function_sidebar->setPosition(-20, 170, ATopRight)->setSize(250, GuiElement::GuiSizeMax)->hide();
+    custom_function_sidebar->setPosition(-270, 20, ATopRight)->setSize(200, GuiElement::GuiSizeMax);
 
     // Scan button.
     scan_button = new GuiScanTargetButton(info_sidebar, "SCAN_BUTTON", &targets);
@@ -252,7 +252,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
             targets.clear();
     }
     
-    sidebar_selector->setVisible(sidebar_selector->getSelectionIndex() > 0 || custom_function_sidebar->hasEntries());
+    sidebar_selector->setVisible(sidebar_selector->getSelectionIndex() > 0 );
 
     info_callsign->setValue("-");
     info_distance->setValue("-");


### PR DESCRIPTION
This fixes #739. It ignores the science sidebar and instead places the custom functions along the same "column" where the waypoint buttons are. Therefore, the width of the buttons/infos is also slightly  smaller than on other stations, but I don't think that would be a big deal.